### PR TITLE
Use grid with fixed-size rows vs flex for RHR region layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,12 @@
       "name": "next-article--layout",
       "version": "0.0.1",
       "dependencies": {
-        "@astrojs/check": "^0.5.10",
-        "astro": "^4.7.1",
+        "@astrojs/check": "^0.7.0",
+        "astro": "^4.8.5",
         "typescript": "^5.4.5"
       },
       "devDependencies": {
-        "sass": "1.76.0"
+        "sass": "1.77.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -29,11 +29,11 @@
       }
     },
     "node_modules/@astrojs/check": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/@astrojs/check/-/check-0.5.10.tgz",
-      "integrity": "sha512-vliHXM9cu/viGeKiksUM4mXfO816ohWtawTl2ADPgTsd4nUMjFiyAl7xFZhF34yy4hq4qf7jvK1F2PlR3b5I5w==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/check/-/check-0.7.0.tgz",
+      "integrity": "sha512-UTqwOeKNu9IYZmJXEeWnQuTdSd/pX58Hl4TUARsMlT97SVDL//kLBE4T/ctxRz6J573N87oE5ddtW/uOOnQTug==",
       "dependencies": {
-        "@astrojs/language-server": "^2.8.4",
+        "@astrojs/language-server": "^2.10.0",
         "chokidar": "^3.5.3",
         "fast-glob": "^3.3.1",
         "kleur": "^4.1.5",
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@astrojs/compiler": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.7.1.tgz",
-      "integrity": "sha512-/POejAYuj8WEw7ZI0J8JBvevjfp9jQ9Wmu/Bg52RiNwGXkMV7JnYpsenVfHvvf1G7R5sXHGKlTcxlQWhoUTiGQ=="
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.8.0.tgz",
+      "integrity": "sha512-yrpD1WRGqsJwANaDIdtHo+YVjvIOFAjC83lu5qENIgrafwZcJgSXDuwVMXOgok4tFzpeKLsFQ6c3FoUdloLWBQ=="
     },
     "node_modules/@astrojs/internal-helpers": {
       "version": "0.4.0",
@@ -57,25 +57,25 @@
       "integrity": "sha512-6B13lz5n6BrbTqCTwhXjJXuR1sqiX/H6rTxzlXx+lN1NnV4jgnq/KJldCQaUWJzPL5SiWahQyinxAbxQtwgPHA=="
     },
     "node_modules/@astrojs/language-server": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.8.4.tgz",
-      "integrity": "sha512-sJH5vGTBkhgA8+hdhzX78UUp4cFz4Mt7xkEkevD188OS5bDMkaue6hK+dtXWM47mnrXFveXA2u38K7S+5+IRjA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.10.0.tgz",
+      "integrity": "sha512-crHXpqYfA5qWioiuZnZFpTsNItgBlF1f0S9MzDYS7/pfCALkHNJ7K3w9U/j0uMKymsT4hC7BfMaX0DYlfdSzHg==",
       "dependencies": {
         "@astrojs/compiler": "^2.7.0",
         "@jridgewell/sourcemap-codec": "^1.4.15",
-        "@volar/kit": "~2.1.5",
-        "@volar/language-core": "~2.1.5",
-        "@volar/language-server": "~2.1.5",
-        "@volar/language-service": "~2.1.5",
-        "@volar/typescript": "~2.1.5",
+        "@volar/kit": "~2.2.3",
+        "@volar/language-core": "~2.2.3",
+        "@volar/language-server": "~2.2.3",
+        "@volar/language-service": "~2.2.3",
+        "@volar/typescript": "~2.2.3",
         "fast-glob": "^3.2.12",
-        "volar-service-css": "0.0.34",
-        "volar-service-emmet": "0.0.34",
-        "volar-service-html": "0.0.34",
-        "volar-service-prettier": "0.0.34",
-        "volar-service-typescript": "0.0.34",
-        "volar-service-typescript-twoslash-queries": "0.0.34",
-        "vscode-html-languageservice": "^5.1.2",
+        "volar-service-css": "0.0.45",
+        "volar-service-emmet": "0.0.45",
+        "volar-service-html": "0.0.45",
+        "volar-service-prettier": "0.0.45",
+        "volar-service-typescript": "0.0.45",
+        "volar-service-typescript-twoslash-queries": "0.0.45",
+        "vscode-html-languageservice": "^5.2.0",
         "vscode-uri": "^3.0.8"
       },
       "bin": {
@@ -498,10 +498,37 @@
         "@emmetio/scanner": "^1.0.4"
       }
     },
+    "node_modules/@emmetio/css-parser": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-parser/-/css-parser-0.4.0.tgz",
+      "integrity": "sha512-z7wkxRSZgrQHXVzObGkXG+Vmj3uRlpM11oCZ9pbaz0nFejvCDmAiNDpY75+wgXOcffKpj4rzGtwGaZxfJKsJxw==",
+      "dependencies": {
+        "@emmetio/stream-reader": "^2.2.0",
+        "@emmetio/stream-reader-utils": "^0.1.0"
+      }
+    },
+    "node_modules/@emmetio/html-matcher": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/html-matcher/-/html-matcher-1.3.0.tgz",
+      "integrity": "sha512-NTbsvppE5eVyBMuyGfVu2CRrLvo7J4YHb6t9sBFLyY03WYhXET37qA4zOYUjBWFCRHO7pS1B9khERtY0f5JXPQ==",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.0"
+      }
+    },
     "node_modules/@emmetio/scanner": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.4.tgz",
       "integrity": "sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA=="
+    },
+    "node_modules/@emmetio/stream-reader": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader/-/stream-reader-2.2.0.tgz",
+      "integrity": "sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw=="
+    },
+    "node_modules/@emmetio/stream-reader-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader-utils/-/stream-reader-utils-0.1.0.tgz",
+      "integrity": "sha512-ZsZ2I9Vzso3Ho/pjZFsmmZ++FWeEd/txqybHTm4OgaZzdS8V9V/YYWQwg5TC38Z7uLWUV1vavpLLbjJtKubR1A=="
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.1.1",
@@ -1556,9 +1583,9 @@
       ]
     },
     "node_modules/@shikijs/core": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.3.0.tgz",
-      "integrity": "sha512-7fedsBfuILDTBmrYZNFI8B6ATTxhQAasUHllHmjvSZPnoq4bULWoTpHwmuQvZ8Aq03/tAa2IGo6RXqWtHdWaCA=="
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.5.2.tgz",
+      "integrity": "sha512-wSAOgaz48GmhILFElMCeQypSZmj6Ru6DttOOtl3KNkdJ17ApQuGNCfzpk4cClasVrnIu45++2DBwG4LNMQAfaA=="
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1660,12 +1687,12 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
     },
     "node_modules/@volar/kit": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@volar/kit/-/kit-2.1.6.tgz",
-      "integrity": "sha512-dSuXChDGM0nSG/0fxqlNfadjpAeeo1P1SJPBQ+pDf8H1XrqeJq5gIhxRTEbiS+dyNIG69ATq1CArkbCif+oxJw==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@volar/kit/-/kit-2.2.4.tgz",
+      "integrity": "sha512-TyRYaj56NBwa+0DgYbIkNQm+pN5DaV1dvZ5PzoKGDk9oag/sCG+W6wVkyaqmYCNJkXpmRtM627RkeMRTBvnYzw==",
       "dependencies": {
-        "@volar/language-service": "2.1.6",
-        "@volar/typescript": "2.1.6",
+        "@volar/language-service": "2.2.4",
+        "@volar/typescript": "2.2.4",
         "typesafe-path": "^0.2.2",
         "vscode-languageserver-textdocument": "^1.0.11",
         "vscode-uri": "^3.0.8"
@@ -1675,22 +1702,22 @@
       }
     },
     "node_modules/@volar/language-core": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.1.6.tgz",
-      "integrity": "sha512-pAlMCGX/HatBSiDFMdMyqUshkbwWbLxpN/RL7HCQDOo2gYBE+uS+nanosLc1qR6pTQ/U8q00xt8bdrrAFPSC0A==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.2.4.tgz",
+      "integrity": "sha512-7As47GndxGxsqqYnbreLrfB5NDUeQioPM2LJKUuB4/34c0NpEJ2byVl3c9KYdjIdiEstWZ9JLtLKNTaPWb5jtA==",
       "dependencies": {
-        "@volar/source-map": "2.1.6"
+        "@volar/source-map": "2.2.4"
       }
     },
     "node_modules/@volar/language-server": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@volar/language-server/-/language-server-2.1.6.tgz",
-      "integrity": "sha512-0w+FV8ro37hVb3qE4ONo3VbS5kEQXv4H/D2xCePyY5dRw6XnbJAPFNKvoxI9mxHTPonvIG1si5rN9MSGSKtgZQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@volar/language-server/-/language-server-2.2.4.tgz",
+      "integrity": "sha512-wgRsKsqFMY7MRkmBfIX+GB0uzAv2Nks7YS3Ud6RWdHsjEu7tF+cXzBX/IRgW5HOayLLPC1xES2PYXk26hdOIoA==",
       "dependencies": {
-        "@volar/language-core": "2.1.6",
-        "@volar/language-service": "2.1.6",
-        "@volar/snapshot-document": "2.1.6",
-        "@volar/typescript": "2.1.6",
+        "@volar/language-core": "2.2.4",
+        "@volar/language-service": "2.2.4",
+        "@volar/snapshot-document": "2.2.4",
+        "@volar/typescript": "2.2.4",
         "@vscode/l10n": "^0.0.16",
         "path-browserify": "^1.0.1",
         "request-light": "^0.7.0",
@@ -1701,39 +1728,39 @@
       }
     },
     "node_modules/@volar/language-service": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@volar/language-service/-/language-service-2.1.6.tgz",
-      "integrity": "sha512-1OpbbPQ6wUIumwMP5r45y8utVEmvq1n6BC8JHqGKsuFr9RGFIldDBlvA/xuO3MDKhjmmPGPHKb54kg1/YN78ow==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@volar/language-service/-/language-service-2.2.4.tgz",
+      "integrity": "sha512-3OxJFADEsAZp1RoTS3SX2GY9SeVnB9mbd3N/Faz45IvnT2EFAyVJGPOyrz5bJDvKuCtjdoTNNWS1GX1bHGytrA==",
       "dependencies": {
-        "@volar/language-core": "2.1.6",
+        "@volar/language-core": "2.2.4",
         "vscode-languageserver-protocol": "^3.17.5",
         "vscode-languageserver-textdocument": "^1.0.11",
         "vscode-uri": "^3.0.8"
       }
     },
     "node_modules/@volar/snapshot-document": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@volar/snapshot-document/-/snapshot-document-2.1.6.tgz",
-      "integrity": "sha512-YNYk1sCOrGg7VHbZM+1It97q0GWhFxdqIwnxSNFoL0X1LuSRXoCT2DRb/aa1J6aBpPMbKqSFUWHGQEAFUnc4Zw==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@volar/snapshot-document/-/snapshot-document-2.2.4.tgz",
+      "integrity": "sha512-XwL9Jo5+nn4WZystok1+kRXbmFuJXaCx0KfJYZizJQDd7kPDgBcyci/aKsBVNhIgiD9JT0KKycru0ndyHRadGQ==",
       "dependencies": {
         "vscode-languageserver-protocol": "^3.17.5",
         "vscode-languageserver-textdocument": "^1.0.11"
       }
     },
     "node_modules/@volar/source-map": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.1.6.tgz",
-      "integrity": "sha512-TeyH8pHHonRCHYI91J7fWUoxi0zWV8whZTVRlsWHSYfjm58Blalkf9LrZ+pj6OiverPTmrHRkBsG17ScQyWECw==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.2.4.tgz",
+      "integrity": "sha512-m92FLpR9vB1YEZfiZ+bfgpLrToL/DNkOrorWVep3pffHrwwI4Tx2oIQN+sqHJfKkiT5N3J1owC+8crhAEinfjg==",
       "dependencies": {
         "muggle-string": "^0.4.0"
       }
     },
     "node_modules/@volar/typescript": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.1.6.tgz",
-      "integrity": "sha512-JgPGhORHqXuyC3r6skPmPHIZj4LoMmGlYErFTuPNBq9Nhc9VTv7ctHY7A3jMN3ngKEfRrfnUcwXHztvdSQqNfw==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.2.4.tgz",
+      "integrity": "sha512-uAQC53tgEbHO62G8NXMfmBrJAlP2QJ9WxVEEQqqK3I6VSy8frL5LbH3hAWODxiwMWixv74wJLWlKbWXOgdIoRQ==",
       "dependencies": {
-        "@volar/language-core": "2.1.6",
+        "@volar/language-core": "2.2.4",
         "path-browserify": "^1.0.1"
       }
     },
@@ -1872,11 +1899,11 @@
       }
     },
     "node_modules/astro": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-4.7.1.tgz",
-      "integrity": "sha512-3o+VmnIPBiCm0QVyyTC/F8humNXny5YpI+MKvBTksviRtKxhnztEA3+GAR2XWLUSOx1+/GVjz7mExq3hJGOeqQ==",
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-4.8.5.tgz",
+      "integrity": "sha512-h+t4VGLPBk6KjIiJnYGotJ16wsLIdmNVSvnwEk51XhqZ5T2VlbozgDtgDi6y3qP3mqkhpN3Q39YQORhVeuEYsg==",
       "dependencies": {
-        "@astrojs/compiler": "^2.7.1",
+        "@astrojs/compiler": "^2.8.0",
         "@astrojs/internal-helpers": "0.4.0",
         "@astrojs/markdown-remark": "5.1.0",
         "@astrojs/telemetry": "3.1.0",
@@ -1905,7 +1932,7 @@
         "dlv": "^1.1.3",
         "dset": "^3.1.3",
         "es-module-lexer": "^1.5.2",
-        "esbuild": "^0.20.2",
+        "esbuild": "^0.21.2",
         "estree-walker": "^3.0.3",
         "execa": "^8.0.1",
         "fast-glob": "^3.3.2",
@@ -1926,18 +1953,18 @@
         "prompts": "^2.4.2",
         "rehype": "^13.0.1",
         "resolve": "^1.22.8",
-        "semver": "^7.6.0",
-        "shiki": "^1.3.0",
+        "semver": "^7.6.2",
+        "shiki": "^1.5.1",
         "string-width": "^7.1.0",
         "strip-ansi": "^7.1.0",
         "tsconfck": "^3.0.3",
         "unist-util-visit": "^5.0.0",
         "vfile": "^6.0.1",
-        "vite": "^5.2.10",
+        "vite": "^5.2.11",
         "vitefu": "^0.2.5",
         "which-pm": "^2.1.1",
         "yargs-parser": "^21.1.1",
-        "zod": "^3.23.5",
+        "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.0"
       },
       "bin": {
@@ -1950,6 +1977,388 @@
       },
       "optionalDependencies": {
         "sharp": "^0.33.3"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.3.tgz",
+      "integrity": "sha512-yTgnwQpFVYfvvo4SvRFB0SwrW8YjOxEoT7wfMT7Ol5v7v5LDNvSGo67aExmxOb87nQNeWPVvaGBNfQ7BXcrZ9w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/android-arm": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.3.tgz",
+      "integrity": "sha512-bviJOLMgurLJtF1/mAoJLxDZDL6oU5/ztMHnJQRejbJrSc9FFu0QoUoFhvi6qSKJEw9y5oGyvr9fuDtzJ30rNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.3.tgz",
+      "integrity": "sha512-c+ty9necz3zB1Y+d/N+mC6KVVkGUUOcm4ZmT5i/Fk5arOaY3i6CA3P5wo/7+XzV8cb4GrI/Zjp8NuOQ9Lfsosw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/android-x64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.3.tgz",
+      "integrity": "sha512-JReHfYCRK3FVX4Ra+y5EBH1b9e16TV2OxrPAvzMsGeES0X2Ndm9ImQRI4Ket757vhc5XBOuGperw63upesclRw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.3.tgz",
+      "integrity": "sha512-U3fuQ0xNiAkXOmQ6w5dKpEvXQRSpHOnbw7gEfHCRXPeTKW9sBzVck6C5Yneb8LfJm0l6le4NQfkNPnWMSlTFUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.3.tgz",
+      "integrity": "sha512-3m1CEB7F07s19wmaMNI2KANLcnaqryJxO1fXHUV5j1rWn+wMxdUYoPyO2TnAbfRZdi7ADRwJClmOwgT13qlP3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.3.tgz",
+      "integrity": "sha512-fsNAAl5pU6wmKHq91cHWQT0Fz0vtyE1JauMzKotrwqIKAswwP5cpHUCxZNSTuA/JlqtScq20/5KZ+TxQdovU/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.3.tgz",
+      "integrity": "sha512-tci+UJ4zP5EGF4rp8XlZIdq1q1a/1h9XuronfxTMCNBslpCtmk97Q/5qqy1Mu4zIc0yswN/yP/BLX+NTUC1bXA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.3.tgz",
+      "integrity": "sha512-f6kz2QpSuyHHg01cDawj0vkyMwuIvN62UAguQfnNVzbge2uWLhA7TCXOn83DT0ZvyJmBI943MItgTovUob36SQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.3.tgz",
+      "integrity": "sha512-vvG6R5g5ieB4eCJBQevyDMb31LMHthLpXTc2IGkFnPWS/GzIFDnaYFp558O+XybTmYrVjxnryru7QRleJvmZ6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.3.tgz",
+      "integrity": "sha512-HjCWhH7K96Na+66TacDLJmOI9R8iDWDDiqe17C7znGvvE4sW1ECt9ly0AJ3dJH62jHyVqW9xpxZEU1jKdt+29A==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.3.tgz",
+      "integrity": "sha512-BGpimEccmHBZRcAhdlRIxMp7x9PyJxUtj7apL2IuoG9VxvU/l/v1z015nFs7Si7tXUwEsvjc1rOJdZCn4QTU+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.3.tgz",
+      "integrity": "sha512-5rMOWkp7FQGtAH3QJddP4w3s47iT20hwftqdm7b+loe95o8JU8ro3qZbhgMRy0VuFU0DizymF1pBKkn3YHWtsw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.3.tgz",
+      "integrity": "sha512-h0zj1ldel89V5sjPLo5H1SyMzp4VrgN1tPkN29TmjvO1/r0MuMRwJxL8QY05SmfsZRs6TF0c/IDH3u7XYYmbAg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.3.tgz",
+      "integrity": "sha512-dkAKcTsTJ+CRX6bnO17qDJbLoW37npd5gSNtSzjYQr0svghLJYGYB0NF1SNcU1vDcjXLYS5pO4qOW4YbFama4A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.3.tgz",
+      "integrity": "sha512-vnD1YUkovEdnZWEuMmy2X2JmzsHQqPpZElXx6dxENcIwTu+Cu5ERax6+Ke1QsE814Zf3c6rxCfwQdCTQ7tPuXA==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.3.tgz",
+      "integrity": "sha512-IOXOIm9WaK7plL2gMhsWJd+l2bfrhfilv0uPTptoRoSb2p09RghhQQp9YY6ZJhk/kqmeRt6siRdMSLLwzuT0KQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.3.tgz",
+      "integrity": "sha512-uTgCwsvQ5+vCQnqM//EfDSuomo2LhdWhFPS8VL8xKf+PKTCrcT/2kPPoWMTs22aB63MLdGMJiE3f1PHvCDmUOw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.3.tgz",
+      "integrity": "sha512-vNAkR17Ub2MgEud2Wag/OE4HTSI6zlb291UYzHez/psiKarp0J8PKGDnAhMBcHFoOHMXHfExzmjMojJNbAStrQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.3.tgz",
+      "integrity": "sha512-W8H9jlGiSBomkgmouaRoTXo49j4w4Kfbl6I1bIdO/vT0+0u4f20ko3ELzV3hPI6XV6JNBVX+8BC+ajHkvffIJA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.3.tgz",
+      "integrity": "sha512-EjEomwyLSCg8Ag3LDILIqYCZAq/y3diJ04PnqGRgq8/4O3VNlXyMd54j/saShaN4h5o5mivOjAzmU6C3X4v0xw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.3.tgz",
+      "integrity": "sha512-WGiE/GgbsEwR33++5rzjiYsKyHywE8QSZPF7Rfx9EBfK3Qn3xyR6IjyCr5Uk38Kg8fG4/2phN7sXp4NPWd3fcw==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.3.tgz",
+      "integrity": "sha512-xRxC0jaJWDLYvcUvjQmHCJSfMrgmUuvsoXgDeU/wTorQ1ngDdUBuFtgY3W1Pc5sprGAvZBtWdJX7RPg/iZZUqA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/astro/node_modules/esbuild": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.3.tgz",
+      "integrity": "sha512-Kgq0/ZsAPzKrbOjCQcjoSmPoWhlcVnGAUo7jvaLHoxW1Drto0KGkR1xBNg2Cp43b9ImvxmPEJZ9xkfcnqPsfBw==",
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.3",
+        "@esbuild/android-arm": "0.21.3",
+        "@esbuild/android-arm64": "0.21.3",
+        "@esbuild/android-x64": "0.21.3",
+        "@esbuild/darwin-arm64": "0.21.3",
+        "@esbuild/darwin-x64": "0.21.3",
+        "@esbuild/freebsd-arm64": "0.21.3",
+        "@esbuild/freebsd-x64": "0.21.3",
+        "@esbuild/linux-arm": "0.21.3",
+        "@esbuild/linux-arm64": "0.21.3",
+        "@esbuild/linux-ia32": "0.21.3",
+        "@esbuild/linux-loong64": "0.21.3",
+        "@esbuild/linux-mips64el": "0.21.3",
+        "@esbuild/linux-ppc64": "0.21.3",
+        "@esbuild/linux-riscv64": "0.21.3",
+        "@esbuild/linux-s390x": "0.21.3",
+        "@esbuild/linux-x64": "0.21.3",
+        "@esbuild/netbsd-x64": "0.21.3",
+        "@esbuild/openbsd-x64": "0.21.3",
+        "@esbuild/sunos-x64": "0.21.3",
+        "@esbuild/win32-arm64": "0.21.3",
+        "@esbuild/win32-ia32": "0.21.3",
+        "@esbuild/win32-x64": "0.21.3"
       }
     },
     "node_modules/axobject-query": {
@@ -5369,9 +5778,9 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.76.0.tgz",
-      "integrity": "sha512-nc3LeqvF2FNW5xGF1zxZifdW3ffIz5aBb7I7tSvOoNu7z1RQ6pFt9MBuiPtjgaI62YWrM/txjWlOCFiGtf2xpw==",
+      "version": "1.77.2",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.2.tgz",
+      "integrity": "sha512-eb4GZt1C3avsX3heBNlrc7I09nyT00IUuo4eFhAbeXWU2fvA7oXI53SxODVAA+zgZCk9aunAZgO+losjR3fAwA==",
       "devOptional": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -5398,34 +5807,15 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semver/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/sharp": {
       "version": "0.33.3",
@@ -5487,11 +5877,11 @@
       }
     },
     "node_modules/shiki": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.3.0.tgz",
-      "integrity": "sha512-9aNdQy/etMXctnPzsje1h1XIGm9YfRcSksKOGqZWXA/qP9G18/8fpz5Bjpma8bOgz3tqIpjERAd6/lLjFyzoww==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.5.2.tgz",
+      "integrity": "sha512-fpPbuSaatinmdGijE7VYUD3hxLozR3ZZ+iAx8Iy2X6REmJGyF5hQl94SgmiUNTospq346nXUVZx0035dyGvIVw==",
       "dependencies": {
-        "@shikijs/core": "1.3.0"
+        "@shikijs/core": "1.5.2"
       }
     },
     "node_modules/signal-exit": {
@@ -5963,9 +6353,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.2.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.10.tgz",
-      "integrity": "sha512-PAzgUZbP7msvQvqdSD+ErD5qGnSFiGOoWmV5yAKUEI0kdhjbH6nMWVyZQC/hSc4aXwc0oJ9aEdIiF9Oje0JFCw==",
+      "version": "5.2.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.11.tgz",
+      "integrity": "sha512-HndV31LWW05i1BLPMUCE1B9E9GFbOu1MbenhS58FuK6owSO5qHm7GiCotrNY1YE5rMeQSFBGmT5ZaLEjFizgiQ==",
       "dependencies": {
         "esbuild": "^0.20.1",
         "postcss": "^8.4.38",
@@ -6030,16 +6420,16 @@
       }
     },
     "node_modules/volar-service-css": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.34.tgz",
-      "integrity": "sha512-C7ua0j80ZD7bsgALAz/cA1bykPehoIa5n+3+Ccr+YLpj0fypqw9iLUmGLX11CqzqNCO2XFGe/1eXB/c+SWrF/g==",
+      "version": "0.0.45",
+      "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.45.tgz",
+      "integrity": "sha512-f+AlUI1+kESbcZSVaNJVAnK0c/9Da5StoxzPqA5/8VqUHJWNdubWNnwG5xpFVTfgh6pgTcey3UBhBfHytFaIOg==",
       "dependencies": {
         "vscode-css-languageservice": "^6.2.10",
         "vscode-languageserver-textdocument": "^1.0.11",
         "vscode-uri": "^3.0.8"
       },
       "peerDependencies": {
-        "@volar/language-service": "~2.1.0"
+        "@volar/language-service": "~2.2.3"
       },
       "peerDependenciesMeta": {
         "@volar/language-service": {
@@ -6048,15 +6438,16 @@
       }
     },
     "node_modules/volar-service-emmet": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/volar-service-emmet/-/volar-service-emmet-0.0.34.tgz",
-      "integrity": "sha512-ubQvMCmHPp8Ic82LMPkgrp9ot+u2p/RDd0RyT0EykRkZpWsagHUF5HWkVheLfiMyx2rFuWx/+7qZPOgypx6h6g==",
+      "version": "0.0.45",
+      "resolved": "https://registry.npmjs.org/volar-service-emmet/-/volar-service-emmet-0.0.45.tgz",
+      "integrity": "sha512-9nLXSDkR1vA/3fQkFEsSXAu3XovQxOpTkVG2jilQgfek/K1ZLkaA/WMhN/TtmPmQg4NxE9Ni6mA5udBQ5gVXIA==",
       "dependencies": {
-        "@vscode/emmet-helper": "^2.9.2",
-        "vscode-html-languageservice": "^5.1.0"
+        "@emmetio/css-parser": "^0.4.0",
+        "@emmetio/html-matcher": "^1.3.0",
+        "@vscode/emmet-helper": "^2.9.2"
       },
       "peerDependencies": {
-        "@volar/language-service": "~2.1.0"
+        "@volar/language-service": "~2.2.3"
       },
       "peerDependenciesMeta": {
         "@volar/language-service": {
@@ -6065,16 +6456,16 @@
       }
     },
     "node_modules/volar-service-html": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/volar-service-html/-/volar-service-html-0.0.34.tgz",
-      "integrity": "sha512-kMEneea1tQbiRcyKavqdrSVt8zV06t+0/3pGkjO3gV6sikXTNShIDkdtB4Tq9vE2cQdM50TuS7utVV7iysUxHw==",
+      "version": "0.0.45",
+      "resolved": "https://registry.npmjs.org/volar-service-html/-/volar-service-html-0.0.45.tgz",
+      "integrity": "sha512-tLTJqfy1v5C4nmeAsfekFIKPl4r4qDMyL0L9MWywr/EApZzPCsbeUGxCqdzxSMC2q7PMCfX2i167txDo+J0LVA==",
       "dependencies": {
-        "vscode-html-languageservice": "^5.1.0",
+        "vscode-html-languageservice": "npm:@johnsoncodehk/vscode-html-languageservice@5.2.0-34a5462",
         "vscode-languageserver-textdocument": "^1.0.11",
         "vscode-uri": "^3.0.8"
       },
       "peerDependencies": {
-        "@volar/language-service": "~2.1.0"
+        "@volar/language-service": "~2.2.3"
       },
       "peerDependenciesMeta": {
         "@volar/language-service": {
@@ -6082,15 +6473,32 @@
         }
       }
     },
+    "node_modules/volar-service-html/node_modules/@vscode/l10n": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
+      "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ=="
+    },
+    "node_modules/volar-service-html/node_modules/vscode-html-languageservice": {
+      "name": "@johnsoncodehk/vscode-html-languageservice",
+      "version": "5.2.0-34a5462",
+      "resolved": "https://registry.npmjs.org/@johnsoncodehk/vscode-html-languageservice/-/vscode-html-languageservice-5.2.0-34a5462.tgz",
+      "integrity": "sha512-etqLfpSJ5zaw76KUNF603be6d6QsiQPmaHr9FKEp4zhLZJzWCCMH6Icak7MtLUFLZLMpL761mZNImi/joBo1ZA==",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-languageserver-types": "^3.17.5",
+        "vscode-uri": "^3.0.8"
+      }
+    },
     "node_modules/volar-service-prettier": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/volar-service-prettier/-/volar-service-prettier-0.0.34.tgz",
-      "integrity": "sha512-BNfJ8FwfPi1Wm/JkuzNjraOLdtKieGksNT/bDyquygVawv1QUzO2HB1hiMKfZGdcSFG5ZL9R0j7bBfRTfXA2gg==",
+      "version": "0.0.45",
+      "resolved": "https://registry.npmjs.org/volar-service-prettier/-/volar-service-prettier-0.0.45.tgz",
+      "integrity": "sha512-+mBS2EsDgp/kunKEBnHvhBwIQm5v2ahw4NKpKdg4sTpXy3UxqHt+Fq/wRYQ7Z8LlNVNRVfp75ThjM+w2zaZBAw==",
       "dependencies": {
         "vscode-uri": "^3.0.8"
       },
       "peerDependencies": {
-        "@volar/language-service": "~2.1.0",
+        "@volar/language-service": "~2.2.3",
         "prettier": "^2.2 || ^3.0"
       },
       "peerDependenciesMeta": {
@@ -6103,9 +6511,9 @@
       }
     },
     "node_modules/volar-service-typescript": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/volar-service-typescript/-/volar-service-typescript-0.0.34.tgz",
-      "integrity": "sha512-NbAry0w8ZXFgGsflvMwmPDCzgJGx3C+eYxFEbldaumkpTAJiywECWiUbPIOfmEHgpOllUKSnhwtLlWFK4YnfQg==",
+      "version": "0.0.45",
+      "resolved": "https://registry.npmjs.org/volar-service-typescript/-/volar-service-typescript-0.0.45.tgz",
+      "integrity": "sha512-i/mMIIAMastJ2kgPo3qvX0Rrl7NyxhIYZ0ug/B4ambZcLPI1vzBgS2fmvyWX3jhBYHh8NmbAotFj+0Y9JtN47A==",
       "dependencies": {
         "path-browserify": "^1.0.1",
         "semver": "^7.5.4",
@@ -6114,7 +6522,7 @@
         "vscode-nls": "^5.2.0"
       },
       "peerDependencies": {
-        "@volar/language-service": "~2.1.0"
+        "@volar/language-service": "~2.2.3"
       },
       "peerDependenciesMeta": {
         "@volar/language-service": {
@@ -6123,11 +6531,11 @@
       }
     },
     "node_modules/volar-service-typescript-twoslash-queries": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/volar-service-typescript-twoslash-queries/-/volar-service-typescript-twoslash-queries-0.0.34.tgz",
-      "integrity": "sha512-XAY2YtWKUp6ht89gxt3L5Dr46LU45d/VlBkj1KXUwNlinpoWiGN4Nm3B6DRF3VoBThAnQgm4c7WD0S+5yTzh+w==",
+      "version": "0.0.45",
+      "resolved": "https://registry.npmjs.org/volar-service-typescript-twoslash-queries/-/volar-service-typescript-twoslash-queries-0.0.45.tgz",
+      "integrity": "sha512-KrPUUvKggZgV9mrDpstCzmf20irgv0ooMv+FGDzIIQUkya+d2+nSS8Mx2h9FvsYgLccUVw5jU3Rhwhd3pv/7qg==",
       "peerDependencies": {
-        "@volar/language-service": "~2.1.0"
+        "@volar/language-service": "~2.2.3"
       },
       "peerDependenciesMeta": {
         "@volar/language-service": {
@@ -6428,9 +6836,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.23.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.6.tgz",
-      "integrity": "sha512-RTHJlZhsRbuA8Hmp/iNL7jnfc4nZishjsanDAfEY1QpDQZCahUp3xDzl+zfweE9BklxMUcgBgS1b7Lvie/ZVwA==",
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/check": "^0.5.10",
-    "astro": "^4.7.1",
+    "@astrojs/check": "^0.7.0",
+    "astro": "^4.8.5",
     "typescript": "^5.4.5"
   },
   "devDependencies": {
-    "sass": "1.76.0"
+    "sass": "1.77.2"
   }
 }

--- a/src/client/ads/rhr.ts
+++ b/src/client/ads/rhr.ts
@@ -20,6 +20,7 @@ export class RightHandRail {
     const contentElObserver = new ResizeObserver(
       this.onContentElResize.bind(this)
     );
+
     contentElObserver.observe(this.contentEl);
     contentElObserver.observe(rootEl);
   }
@@ -45,6 +46,20 @@ export class RightHandRail {
         region.appendChild(item);
       }
     }
+  }
+
+  appendItem(item: Element) {
+    for (const region of this.#rhrRegions) {
+      const regionHeight = region.getBoundingClientRect().height;
+      const regionMax = Math.floor(regionHeight / this.minRegionHeight);
+
+      if (region.children.length < regionMax) {
+        region.appendChild(item);
+        return true;
+      }
+    }
+
+    return false;
   }
 
   get isIntersected() {
@@ -139,7 +154,7 @@ export class RightHandRail {
     const regionEls = [];
     for (const { top, height } of rects) {
       const regionEl = document.createElement("div");
-      regionEl.className = "rhr-region";
+      regionEl.className = "rhr-region rhr-region-flex";
       regionEl.style.top = `${top}px`;
       regionEl.style.height = `${height}px`;
 

--- a/src/client/ads/rhr.ts
+++ b/src/client/ads/rhr.ts
@@ -16,10 +16,12 @@ export class RightHandRail {
     this.#contentGroups = this.initContentGroups();
     this.#rhrRegions = this.initRhrRegions();
 
+    const rootEl = document.querySelector(":root")!;
     const contentElObserver = new ResizeObserver(
       this.onContentElResize.bind(this)
     );
     contentElObserver.observe(this.contentEl);
+    contentElObserver.observe(rootEl);
   }
 
   // Public API
@@ -108,7 +110,7 @@ export class RightHandRail {
   getContentGroupRects() {
     const contentTop = this.contentEl.getBoundingClientRect().top;
     const rhrTop = this.rhrEl.getBoundingClientRect().top;
-    const topDiff = contentTop - rhrTop;
+    const topDiff = rhrTop - contentTop;
     const offsetY = contentTop + topDiff;
 
     const rects = [];

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -37,8 +37,13 @@ function runDemo() {
     const articleRhrEl = document.querySelector("#article-rhr")!;
     const conceptListEl = articleRhrEl.querySelector<HTMLElement>(".concepts")!;
 
+    const numSlots = parseInt(new URLSearchParams(document.location.search).get("numItems") ?? "2");
+
     const articleRhr = new RightHandRail(articleContentEl, articleRhrEl);
-    const items = configureSlots(createSlots(4), articleRhr.isIntersected);
+    const items = configureSlots(createSlots(numSlots), articleRhr.isIntersected);
+
+    // @ts-ignore
+    window.articleRhr = articleRhr;
 
     // If there's no fullbleed content then add the desktop Concept List
     // into the items to be placed in the RHR
@@ -56,6 +61,7 @@ function runDemo() {
     // Here we place the slots that didn't fit `articleRhr` into `commentsRhr`
     // We also update them to allow 600px MPUs: `commentsRhr.isIntersected` is false
     commentsRhr.placeItems(configureSlots(items, commentsRhr.isIntersected));
+
   } catch (err) {
     console.error(err);
   }

--- a/src/demo/controls.ts
+++ b/src/demo/controls.ts
@@ -22,6 +22,9 @@ function initControls({
   toggleTopperBtn,
   toggleImgBtn,
   toggleZoomBtn,
+  toggleGridFlexBtn,
+  insertItemBtn,
+  increaseInitialItemsBtn,
   demoEl,
 }: Record<string, Element>) {
   const onResize = resizeImages();
@@ -35,11 +38,43 @@ function initControls({
   toggleTopperBtn?.addEventListener("click", () => {
     document.body.classList.toggle("no-topper");
   });
+
+  toggleGridFlexBtn?.addEventListener("click", () => {
+    document.querySelectorAll('.rhr-region').forEach((el) => {
+      if (el.classList.contains('rhr-region-flex')) {
+        el.classList.remove('rhr-region-flex');
+        el.classList.add('rhr-region-grid');
+      } else {
+        el.classList.remove('rhr-region-grid');
+        el.classList.add('rhr-region-flex');
+      }
+    });
+  });
+
+  insertItemBtn?.addEventListener("click", () => {
+    const slot = document.createElement("pg-slot");
+    slot.innerHTML = `<span>Sorry I'm late!</span>`;
+
+    // @ts-ignore
+    window.articleRhr.appendItem(slot)
+  });
+
+  increaseInitialItemsBtn.querySelector('.demo-controls__num-items')!.textContent
+    = new URLSearchParams(document.location.search).get("numItems") ?? "2";
+
+  increaseInitialItemsBtn?.addEventListener("click", () => {
+    const numItems = parseInt(new URLSearchParams(document.location.search).get("numItems") ?? "2");
+    document.location.replace(`?numItems=${(numItems % 4) + 1}`);
+  });
 }
+
 
 initControls({
   demoEl: document.querySelector(".demo")!,
   toggleTopperBtn: document.querySelector("[data-click='toggleTopper']")!,
   toggleImgBtn: document.querySelector("[data-click='toggleImages']")!,
   toggleZoomBtn: document.querySelector("[data-click='toggleZoom']")!,
+  toggleGridFlexBtn: document.querySelector("[data-click='toggleGridFlex']")!,
+  insertItemBtn: document.querySelector("[data-click='insertNewItem']")!,
+  increaseInitialItemsBtn: document.querySelector("[data-click='increaseInitialItems']")!,
 });

--- a/src/demo/controls.ts
+++ b/src/demo/controls.ts
@@ -1,6 +1,10 @@
 function resizeImages() {
-  const elsA = document.querySelectorAll("[src='https://placehold.co/800x400']");
-  const elsB = document.querySelectorAll("[src='https://placehold.co/2000x400']");
+  const elsA = document.querySelectorAll(
+    "[src='https://placehold.co/800x400']"
+  );
+  const elsB = document.querySelectorAll(
+    "[src='https://placehold.co/2000x400']"
+  );
   let counter = 0;
 
   return () => {
@@ -14,7 +18,12 @@ function resizeImages() {
   };
 }
 
-function initControls({ toggleImgBtn, toggleZoomBtn, demoEl }: Record<string, Element>) {
+function initControls({
+  toggleTopperBtn,
+  toggleImgBtn,
+  toggleZoomBtn,
+  demoEl,
+}: Record<string, Element>) {
   const onResize = resizeImages();
   toggleImgBtn?.addEventListener("click", onResize);
 
@@ -22,10 +31,15 @@ function initControls({ toggleImgBtn, toggleZoomBtn, demoEl }: Record<string, El
     const zoomed = demoEl?.classList.toggle("demo--zoomed");
     toggleZoomBtn.textContent = zoomed ? "Zoom In" : "Zoom Out";
   });
+
+  toggleTopperBtn?.addEventListener("click", () => {
+    document.body.classList.toggle("no-topper");
+  });
 }
 
 initControls({
   demoEl: document.querySelector(".demo")!,
+  toggleTopperBtn: document.querySelector("[data-click='toggleTopper']")!,
   toggleImgBtn: document.querySelector("[data-click='toggleImages']")!,
   toggleZoomBtn: document.querySelector("[data-click='toggleZoom']")!,
 });

--- a/src/layouts/base.astro
+++ b/src/layouts/base.astro
@@ -46,6 +46,13 @@ const currentPath = Astro.url.pathname;
         </ul>
       </nav>
       <div class="demo-controls__list">
+        <button data-click="toggleGridFlex">Toggle region grid/flex</button>
+        <button data-click="insertNewItem">Insert new item</button>
+        <button data-click="increaseInitialItems">
+          Initial items: <span class="demo-controls__num-items">?</span>
+        </button>
+      </div>
+      <div class="demo-controls__list">
         <button data-click="toggleTopper">Toggle topper / Main image</button>
         <button data-click="toggleImages">Toggle image heights</button>
         <button data-click="toggleZoom">Zoom out</button>
@@ -55,7 +62,6 @@ const currentPath = Astro.url.pathname;
     <script src="../demo/pg-slot.ts"></script>
     <script src="../demo/lorem.ts"></script>
     <script src="../demo/controls.ts"></script>
-
     <script src="../client/index.ts"></script>
   </body>
 </html>

--- a/src/layouts/base.astro
+++ b/src/layouts/base.astro
@@ -46,6 +46,7 @@ const currentPath = Astro.url.pathname;
         </ul>
       </nav>
       <div class="demo-controls__list">
+        <button data-click="toggleTopper">Toggle topper / Main image</button>
         <button data-click="toggleImages">Toggle image heights</button>
         <button data-click="toggleZoom">Zoom out</button>
       </div>

--- a/src/styles/article.css
+++ b/src/styles/article.css
@@ -71,6 +71,7 @@
   .grid__rhr & {
     display: var(--_rhr, none);
   }
+
   .grid__content & {
     display: var(--_content, block);
   }
@@ -90,9 +91,16 @@
   position: absolute;
   left: 0;
   width: 100%;
+}
 
+.rhr-region-flex {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+}
+
+.rhr-region-grid {
   display: grid;
-
   /* 1080px is fixed size of pg slots */
   grid-template-rows: repeat(auto-fill, 1080px);
 }

--- a/src/styles/article.css
+++ b/src/styles/article.css
@@ -91,7 +91,8 @@
   left: 0;
   width: 100%;
 
-  display: flex;
-  flex-direction: column;
-  justify-content: space-around;
+  display: grid;
+
+  /* 1080px is fixed size of pg slots */
+  grid-template-rows: repeat(auto-fill, 1080px);
 }

--- a/src/styles/demo.scss
+++ b/src/styles/demo.scss
@@ -230,10 +230,18 @@ button {
   @include stripes(lightsteelblue);
   @include label("topper");
   aspect-ratio: 32/7;
+
+  .no-topper & {
+    display: none;
+  }
 }
 
 .article__image {
   @include stripes(#fff5);
+
+  .no-topper & {
+    aspect-ratio: 16/9;
+  }
 }
 
 .article__tools {

--- a/src/styles/demo.scss
+++ b/src/styles/demo.scss
@@ -1,11 +1,9 @@
 @mixin stripes($stripe) {
-  background: repeating-linear-gradient(
-    -45deg,
-    transparent 0,
-    transparent 1rem,
-    $stripe 0,
-    $stripe 2rem
-  );
+  background: repeating-linear-gradient(-45deg,
+      transparent 0,
+      transparent 1rem,
+      $stripe 0,
+      $stripe 2rem);
 }
 
 @mixin label($label, $align: right) {
@@ -24,7 +22,8 @@
     bottom: 0;
   }
 
-  @if $align == left {
+  @if $align ==left {
+
     &::before,
     &::after {
       right: auto;
@@ -69,7 +68,7 @@ button {
     margin: 0;
   }
 
-  & p + p {
+  & p+p {
     margin-block-start: 1rem;
   }
 
@@ -124,7 +123,7 @@ button {
   bottom: 0;
   z-index: 1;
 
-  & > * {
+  &>* {
     margin: 1rem;
     padding: 1rem;
     border: 1px solid #000;
@@ -183,6 +182,7 @@ button {
     .grid__content {
       @include label("copy-content");
     }
+
     .grid__rhr {
       @include label("copy-rhr");
     }
@@ -194,6 +194,7 @@ button {
     .grid__content {
       @include label("onward-content");
     }
+
     .grid__rhr {
       @include label("onward-rhr");
     }
@@ -205,6 +206,7 @@ button {
     .grid__content {
       @include label("comments-content");
     }
+
     .grid__rhr {
       @include label("comments-rhr");
     }


### PR DESCRIPTION
This PR changes the way RHR regions are laid-out, using a grid layout vs flex + space-around.

This change aims to prevent content moving around when new items are added "late" to RHR regions with available space, as will likely be the case for the stocks widget.

`justify: space-around` dictates that child items will be positioned with even spacing between them. Using grid + `grid-template-rows: repeat(auto-fill, 1080px);` gives us a fixed set of region 'cells', meaning region items will not move around if another item is added to the region.